### PR TITLE
Package id command

### DIFF
--- a/.ci/appveyor/after.bat
+++ b/.ci/appveyor/after.bat
@@ -1,0 +1,1 @@
+codecov

--- a/.ci/appveyor/install.bat
+++ b/.ci/appveyor/install.bat
@@ -1,0 +1,10 @@
+if not exist "C:\mingw64" appveyor DownloadFile "https://s3-eu-west-1.amazonaws.com/downloads.conan.io/x86_64-6.3.0-release-posix-sjlj-rt_v5-rev1.7z"
+if not exist "C:\mingw64" 7z x x86_64-6.3.0-release-posix-sjlj-rt_v5-rev1.7z -oc:\
+SET PATH=%PYTHON%;%PYTHON%\\Scripts;C:\\mingw64\\bin;%PATH%
+SET PYTHONPATH=%PYTHONPATH%;%CD%
+SET CONAN_LOGGING_LEVEL=10
+SET CONAN_COMPILER=Visual Studio
+SET CONAN_COMPILER_VERSION=12
+%PYTHON%/Scripts/pip.exe install -r conans/requirements.txt
+%PYTHON%/Scripts/pip.exe install -r conans/requirements_dev.txt
+%PYTHON%/Scripts/pip.exe install -r conans/requirements_server.txt

--- a/.ci/appveyor/test.bat
+++ b/.ci/appveyor/test.bat
@@ -1,0 +1,1 @@
+nosetests --with-coverage conans.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,6 @@ matrix:
         
         - language: generic
           os: osx
-          env: PYVER=py34 CONAN_COMPILER=apple-clang CONAN_COMPILER_VERSION=6.0 CONAN_LOGGING_LEVEL=20
-          
-        - language: generic
-          os: osx
-          env: PYVER=py35 CONAN_COMPILER=apple-clang CONAN_COMPILER_VERSION=6.0 CONAN_LOGGING_LEVEL=20
-          
-        - language: generic
-          os: osx
           env: PYVER=py36 CONAN_COMPILER=apple-clang CONAN_COMPILER_VERSION=6.0 CONAN_LOGGING_LEVEL=20
 
 # command to install dependencies

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,32 +1,33 @@
-build: false
-cache:
-    - C:\mingw64-> appveyor.yml
+-
+    branches:
+      only:
+        - /release.*/
+        - master
+    environment:
+      matrix:
+        - PYTHON: "C:\\Python27"
+        - PYTHON: "C:\\Python34"
+        - PYTHON: "C:\\Python35"
+    build: false
+    cache:
+        - C:\mingw64-> appveyor.yml
+    install:
+      - .ci/appveyor/install.bat
+    test_script:
+      - .ci/appveyor/test.bat
+    after_test:
+      - .ci/appveyor/after.bat
 
-environment:
-  matrix:
-    - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python34"
-    - PYTHON: "C:\\Python35"
-
-init:
-  - "ECHO %PYTHON%"
-
-install:
-  - If Not Exist "C:\mingw64" appveyor DownloadFile "https://s3-eu-west-1.amazonaws.com/downloads.conan.io/x86_64-6.3.0-release-posix-sjlj-rt_v5-rev1.7z"
-  - If Not Exist "C:\mingw64" 7z x x86_64-6.3.0-release-posix-sjlj-rt_v5-rev1.7z -oc:\
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;C:\\mingw64\\bin;%PATH%"
-  - "set PYTHONPATH=%PYTHONPATH%;%CD%"
-  - "set CONAN_LOGGING_LEVEL=10"
-  - "set CONAN_COMPILER=Visual Studio"
-  - "set CONAN_COMPILER_VERSION=12"
-  - "%PYTHON%/Scripts/pip.exe install -r conans/requirements.txt"
-  - "%PYTHON%/Scripts/pip.exe install -r conans/requirements_dev.txt"
-  - "%PYTHON%/Scripts/pip.exe install -r conans/requirements_server.txt"
-
-
-test_script:
-  - "nosetests --with-coverage conans.test"
-  
-after_test:
-  - "codecov"
- 
+-
+    environment:
+      matrix:
+        - PYTHON: "C:\\Python35"
+    build: false
+    cache:
+        - C:\mingw64-> appveyor.yml
+    install:
+      - .ci/appveyor/install.bat
+    test_script:
+      - .ci/appveyor/test.bat
+    after_test:
+      - .ci/appveyor/after.bat

--- a/conans/client/client_cache.py
+++ b/conans/client/client_cache.py
@@ -1,7 +1,7 @@
 import os
 
 from conans.errors import ConanException
-from conans.util.files import save, load, mkdir, normalize
+from conans.util.files import save, load, normalize
 from conans.model.settings import Settings
 from conans.client.conf import ConanClientConfigParser, default_client_conf, default_settings_yml
 from conans.model.values import Values
@@ -55,7 +55,6 @@ class ClientCache(SimplePaths):
             return ret
         except Exception:
             raise ConanException("Invalid %s file!" % self.put_headers_path)
-
 
     @property
     def registry(self):
@@ -173,8 +172,3 @@ class ClientCache(SimplePaths):
                     except OSError:
                         break  # not empty
                 ref_path = os.path.dirname(ref_path)
-
-    def profile_path(self, name):
-        if not os.path.exists(self.profiles_path):
-            mkdir(self.profiles_path)
-        return os.path.join(self.profiles_path, name)

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -328,6 +328,8 @@ class Command(object):
         parser.add_argument("--file", "-f", help="specify conanfile filename")
         parser.add_argument("--only", "-n", nargs="?", const="None",
                             help='show fields only')
+        parser.add_argument("--paths", action='store_true', default=False,
+                            help='Show package paths in local cache')
         parser.add_argument("--package_filter", nargs='?',
                             help='print information only for packages that match the filter'
                                  'e.g., MyPackage/1.2@user/channel or MyPackage*')
@@ -361,7 +363,8 @@ class Command(object):
                            filename=args.file,
                            build_order=args.build_order,
                            build_mode=args.build,
-                           graph_filename=args.graph)
+                           graph_filename=args.graph,
+                           show_paths=args.paths)
 
     def build(self, *args):
         """ Utility command to run your current project 'conanfile.py' build() method.
@@ -819,7 +822,6 @@ class Command(object):
         return errors
 
 
-
 def _check_query_parameter_and_get_reference(args):
     reference = None
     if args.pattern:
@@ -831,6 +833,7 @@ def _check_query_parameter_and_get_reference(args):
                                      "reference as search pattern. e.j conan search "
                                      "MyPackage/1.2@user/channel -q \"os=Windows\"")
     return reference
+
 
 def _parse_manifests_arguments(args, reference, current_path):
     if args.manifests and args.manifests_interactive:

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -5,8 +5,8 @@ import os
 import re
 import requests
 import sys
+
 import conans
-from collections import defaultdict
 from conans import __version__ as CLIENT_VERSION, tools
 from conans.client.client_cache import ClientCache
 from conans.client.conf import MIN_SERVER_COMPATIBLE_VERSION, ConanClientConfigParser
@@ -23,17 +23,17 @@ from conans.client.runner import ConanRunner
 from conans.client.store.localdb import LocalDB
 from conans.client.userio import UserIO
 from conans.errors import ConanException
-from conans.model.env_info import EnvValues
 from conans.model.ref import ConanFileReference, is_a_reference
-from conans.model.scope import Scopes
 from conans.model.version import Version
 from conans.paths import CONANFILE, conan_expand_user
 from conans.search.search import DiskSearchManager, DiskSearchAdapter
 from conans.util.config_parser import get_bool_from_text
 from conans.util.env_reader import get_env
-from conans.util.files import rmdir, load, save_files, exception_message_safe
+from conans.util.files import rmdir, save_files, exception_message_safe
 from conans.util.log import logger, configure_logger
 from conans.util.tracer import log_command, log_exception
+from conans.model.profile import Profile
+from conans.client.command_profile_args import profile_from_args
 
 
 class Extender(argparse.Action):
@@ -79,38 +79,6 @@ class Command(object):
     @property
     def client_cache(self):
         return self._client_cache
-
-    def _test_check(self, test_folder, test_folder_name):
-        """ To ensure that the 0.9 version new layout is detected and users warned
-        """
-        # Check old tests, format
-        test_conanfile = os.path.join(test_folder, "conanfile.py")
-        if not os.path.exists(test_conanfile):
-            raise ConanException("Test conanfile.py does not exist")
-        test_conanfile_content = load(test_conanfile)
-        if ".conanfile_directory" not in test_conanfile_content:
-            self._user_io.out.error("""******* conan test command layout has changed *******
-
-In your "%s" folder 'conanfile.py' you should use the
-path to the conanfile_directory, something like:
-
-    self.run('cmake %%s %%s' %% (self.conanfile_directory, cmake.command_line))
-
- """ % test_folder_name)
-
-        # Test the CMakeLists, if existing
-        test_cmake = os.path.join(test_folder, "CMakeLists.txt")
-        if os.path.exists(test_cmake):
-            test_cmake_content = load(test_cmake)
-            if "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake" not in test_cmake_content:
-                self._user_io.out.error("""******* conan test command layout has changed *******
-
-In your "%s" folder 'CMakeLists.txt' you should use the
-path to the CMake binary directory, like this:
-
-   include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-
- """ % test_folder_name)
 
     def new(self, *args):
         """Creates a new package recipe template with a 'conanfile.py'.
@@ -177,6 +145,7 @@ path to the CMake binary directory, like this:
                             help='Optional. Do not remove the source folder in local cache. '
                                  'Use for testing purposes only')
 
+        _add_manifests_arguments(parser)
         _add_common_install_arguments(parser, build_help=_help_build_policies)
 
         args = parser.parse_args(*args)
@@ -210,26 +179,8 @@ path to the CMake binary directory, like this:
         rmdir(build_folder)
         # shutil.copytree(test_folder, build_folder)
 
-        options = _get_tuples_list_from_extender_arg(args.options)
-        env, package_env = _get_simple_and_package_tuples(args.env)
-        env_values = _get_env_values(env, package_env)
-        settings, package_settings = _get_simple_and_package_tuples(args.settings)
-        scopes = Scopes.from_list(args.scope) if args.scope else None
-
-        manager = self._manager
-
-        # Read profile environment and mix with the command line parameters
-        if args.profile:
-            try:
-                profile = manager.read_profile(args.profile, current_path)
-            except ConanException as exc:
-                raise ConanException("Error reading '%s' profile: %s" % (args.profile, exc))
-            else:
-                env_values.update(profile.env_values)
-
-        loader = manager._loader(current_path=None, user_settings_values=settings,
-                                 user_options_values=options, scopes=scopes,
-                                 package_settings=package_settings, env_values=env_values)
+        profile = profile_from_args(args, current_path, self._client_cache.profiles_path)
+        loader = self._manager._loader(conan_info_path=None, profile=profile)
 
         conanfile = loader.load_conan(test_conanfile, self._user_io.out, consumer=True)
         try:
@@ -252,20 +203,19 @@ path to the CMake binary directory, like this:
         if args.build is None and lib_to_test:  # Not specified, force build the tested library
             args.build = [lib_to_test]
 
+        manifests = _parse_manifests_arguments(args, root_folder, current_path)
+        manifest_folder, manifest_interactive, manifest_verify = manifests
         self._manager.install(reference=test_folder,
                               current_path=build_folder,
+                              manifest_folder=manifest_folder,
+                              manifest_verify=manifest_verify,
+                              manifest_interactive=manifest_interactive,
                               remote=args.remote,
-                              options=options,
-                              settings=settings,
-                              package_settings=package_settings,
+                              profile=profile,
                               build_mode=args.build,
-                              scopes=scopes,
                               update=args.update,
-                              generators=["env", "txt"],
-                              profile_name=args.profile,
-                              env_values=env_values
+                              generators=["env", "txt"]
                               )
-        self._test_check(test_folder, test_folder_name)
         self._manager.build(test_folder, build_folder, test=True)
 
     # Alias to test
@@ -297,18 +247,7 @@ path to the CMake binary directory, like this:
         parser.add_argument("--werror", action='store_true', default=False,
                             help='Error instead of warnings for graph inconsistencies')
 
-        # Manifests arguments
-        default_manifest_folder = '.conan_manifests'
-        parser.add_argument("--manifests", "-m", const=default_manifest_folder, nargs="?",
-                            help='Install dependencies manifests in folder for later verify.'
-                            ' Default folder is .conan_manifests, but can be changed')
-        parser.add_argument("--manifests-interactive", "-mi", const=default_manifest_folder,
-                            nargs="?",
-                            help='Install dependencies manifests in folder for later verify, '
-                            'asking user for confirmation. '
-                            'Default folder is .conan_manifests, but can be changed')
-        parser.add_argument("--verify", "-v", const=default_manifest_folder, nargs="?",
-                            help='Verify dependencies manifests against stored ones')
+        _add_manifests_arguments(parser)
 
         parser.add_argument("--no-imports", action='store_true', default=False,
                             help='Install specified packages but avoid running imports')
@@ -333,45 +272,20 @@ path to the CMake binary directory, like this:
                                      "e.g., MyPackage/1.2@user/channel")
             self._manager.download(reference, args.package, remote=args.remote)
         else:  # Classic install, package chosen with settings and options
-            options = _get_tuples_list_from_extender_arg(args.options)
-            settings, package_settings = _get_simple_and_package_tuples(args.settings)
-            env, package_env = _get_simple_and_package_tuples(args.env)
-            env_values = _get_env_values(env, package_env)
-
-            scopes = Scopes.from_list(args.scope) if args.scope else None
-            if args.manifests and args.manifests_interactive:
-                raise ConanException("Do not specify both manifests and "
-                                     "manifests-interactive arguments")
-            if args.verify and (args.manifests or args.manifests_interactive):
-                raise ConanException("Do not specify both 'verify' and "
-                                     "'manifests' or 'manifests-interactive' arguments")
-            manifest_folder = args.verify or args.manifests or args.manifests_interactive
-            if manifest_folder:
-                if not os.path.isabs(manifest_folder):
-                    if isinstance(reference, ConanFileReference):
-                        manifest_folder = os.path.join(current_path, manifest_folder)
-                    else:
-                        manifest_folder = os.path.join(reference, manifest_folder)
-                manifest_verify = args.verify is not None
-                manifest_interactive = args.manifests_interactive is not None
-            else:
-                manifest_verify = manifest_interactive = False
+            manifests = _parse_manifests_arguments(args, reference, current_path)
+            manifest_folder, manifest_interactive, manifest_verify = manifests
+            profile = profile_from_args(args, current_path, self._client_cache.profiles_path)
             self._manager.install(reference=reference,
                                   current_path=current_path,
                                   remote=args.remote,
-                                  options=options,
-                                  settings=settings,
+                                  profile=profile,
                                   build_mode=args.build,
                                   filename=args.file,
                                   update=args.update,
                                   manifest_folder=manifest_folder,
                                   manifest_verify=manifest_verify,
                                   manifest_interactive=manifest_interactive,
-                                  scopes=scopes,
                                   generators=args.generator,
-                                  profile_name=args.profile,
-                                  package_settings=package_settings,
-                                  env_values=env_values,
                                   no_imports=args.no_imports)
 
     def config(self, *args):
@@ -420,43 +334,33 @@ path to the CMake binary directory, like this:
         parser.add_argument("--build_order", "-bo",
                             help='given a modified reference, return an ordered list to build (CI)',
                             nargs=1, action=Extender)
-        parser.add_argument("--graph", "-g", nargs="?", const="graph.dot",
-                            help='Output project dependencies in DOT format for visual graphing')
+        parser.add_argument("--graph", "-g",
+                            help='Creates file with project dependencies graph. It will generate '
+                            'a DOT or HTML file depending on the filename extension')
         build_help = 'given a build policy (same install command "build" parameter), return an ordered list of  ' \
                      'packages that would be built from sources in install command (simulation)'
 
         _add_common_install_arguments(parser, build_help=build_help)
-
         args = parser.parse_args(*args)
-
         log_command("info", vars(args))
-
-        options = _get_tuples_list_from_extender_arg(args.options)
-        settings, package_settings = _get_simple_and_package_tuples(args.settings)
-        env, package_env = _get_simple_and_package_tuples(args.env)
-        env_values = _get_env_values(env, package_env)
 
         current_path = os.getcwd()
         try:
             reference = ConanFileReference.loads(args.reference)
         except:
             reference = os.path.normpath(os.path.join(current_path, args.reference))
-        scopes = Scopes.from_list(args.scope) if args.scope else None
+
+        profile = profile_from_args(args, current_path, self._client_cache.profiles_path)
         self._manager.info(reference=reference,
                            current_path=current_path,
                            remote=args.remote,
-                           options=options,
-                           settings=settings,
-                           package_settings=package_settings,
+                           profile=profile,
                            info=args.only,
-                           filter=args.package_filter,
+                           package_filter=args.package_filter,
                            check_updates=args.update,
                            filename=args.file,
                            build_order=args.build_order,
                            build_mode=args.build,
-                           scopes=scopes,
-                           env_values=env_values,
-                           profile_name=args.profile,
                            graph_filename=args.graph)
 
     def build(self, *args):
@@ -606,27 +510,37 @@ path to the CMake binary directory, like this:
         """
         parser = argparse.ArgumentParser(description=self.remove.__doc__, prog="conan remove")
         parser.add_argument('pattern', help='Pattern name, e.g., openssl/*')
-        parser.add_argument('-p', '--packages', const=[], nargs='?',
-                            help='By default, remove all the packages or select one, '
-                                 'specifying the SHA key')
-        parser.add_argument('-b', '--builds', const=[], nargs='?',
-                            help='By default, remove all the build folders or select one, '
-                                 'specifying the SHA key')
+        parser.add_argument('-p', '--packages',
+                            help='By default, remove all the packages or select one, specifying the package ID',
+                            nargs="*", action=Extender)
+        parser.add_argument('-b', '--builds',
+                            help='By default, remove all the build folders or select one, specifying the package ID',
+                            nargs="*", action=Extender)
+
         parser.add_argument('-s', '--src', default=False, action="store_true",
                             help='Remove source folders')
         parser.add_argument('-f', '--force', default=False,
                             action='store_true', help='Remove without requesting a confirmation')
         parser.add_argument('-r', '--remote', help='Will remove from the specified remote')
+        parser.add_argument('-q', '--query', default=None, help='Packages query: "os=Windows AND '
+                                                                '(arch=x86 OR compiler=gcc)".'
+                                                                ' The "pattern" parameter '
+                                                                'has to be a package recipe '
+                                                                'reference: MyPackage/1.2'
+                                                                '@user/channel')
         args = parser.parse_args(*args)
         log_command("remove", vars(args))
 
-        if args.packages:
-            args.packages = args.packages.split(",")
-        if args.builds:
-            args.builds = args.builds.split(",")
-        self._manager.remove(args.pattern, package_ids_filter=args.packages,
-                             build_ids=args.builds,
-                             src=args.src, force=args.force, remote=args.remote)
+        reference = _check_query_parameter_and_get_reference(args)
+
+        if args.packages is not None and args.query:
+            raise ConanException("'-q' and '-p' parameters can't be used at the same time")
+
+        if args.builds is not None and args.query:
+            raise ConanException("'-q' and '-b' parameters can't be used at the same time")
+
+        self._manager.remove(reference or args.pattern, package_ids_filter=args.packages, build_ids=args.builds,
+                             src=args.src, force=args.force, remote=args.remote, packages_query=args.query)
 
     def copy(self, *args):
         """ Copy conan recipes and packages to another user/channel.
@@ -706,15 +620,7 @@ path to the CMake binary directory, like this:
         args = parser.parse_args(*args)
         log_command("search", vars(args))
 
-        reference = None
-        if args.pattern:
-            try:
-                reference = ConanFileReference.loads(args.pattern)
-            except ConanException:
-                if args.query is not None:
-                    raise ConanException("-q parameter only allowed with a valid recipe "
-                                         "reference as search pattern. e.j conan search "
-                                         "MyPackage/1.2@user/channel -q \"os=Windows\"")
+        reference = _check_query_parameter_and_get_reference(args)
 
         self._manager.search(reference or args.pattern,
                              args.remote,
@@ -840,7 +746,7 @@ path to the CMake binary directory, like this:
             else:
                 self._user_io.out.info("No profiles defined")
         elif args.subcommand == "show":
-            p = self._manager.read_profile(args.profile, os.getcwd())
+            p = Profile.read_file(args.profile, os.getcwd(), self._client_cache.profiles_path)
             Printer(self._user_io.out).print_profile(args.profile, p)
 
     def _show_help(self):
@@ -902,7 +808,7 @@ path to the CMake binary directory, like this:
                 pass
         except Exception as exc:
             # import traceback
-            # logger.debug(traceback.format_exc())
+            # print(traceback.format_exc())
             msg = exception_message_safe(exc)
             try:
                 log_exception(exc, msg)
@@ -911,6 +817,55 @@ path to the CMake binary directory, like this:
             raise exc
 
         return errors
+
+
+
+def _check_query_parameter_and_get_reference(args):
+    reference = None
+    if args.pattern:
+        try:
+            reference = ConanFileReference.loads(args.pattern)
+        except ConanException:
+            if args.query is not None:
+                raise ConanException("-q parameter only allowed with a valid recipe "
+                                     "reference as search pattern. e.j conan search "
+                                     "MyPackage/1.2@user/channel -q \"os=Windows\"")
+    return reference
+
+def _parse_manifests_arguments(args, reference, current_path):
+    if args.manifests and args.manifests_interactive:
+        raise ConanException("Do not specify both manifests and "
+                             "manifests-interactive arguments")
+    if args.verify and (args.manifests or args.manifests_interactive):
+        raise ConanException("Do not specify both 'verify' and "
+                             "'manifests' or 'manifests-interactive' arguments")
+    manifest_folder = args.verify or args.manifests or args.manifests_interactive
+    if manifest_folder:
+        if not os.path.isabs(manifest_folder):
+            if isinstance(reference, ConanFileReference):
+                manifest_folder = os.path.join(current_path, manifest_folder)
+            else:
+                manifest_folder = os.path.join(reference, manifest_folder)
+        manifest_verify = args.verify is not None
+        manifest_interactive = args.manifests_interactive is not None
+    else:
+        manifest_verify = manifest_interactive = False
+
+    return manifest_folder, manifest_interactive, manifest_verify
+
+
+def _add_manifests_arguments(parser):
+    default_manifest_folder = '.conan_manifests'
+    parser.add_argument("--manifests", "-m", const=default_manifest_folder, nargs="?",
+                        help='Install dependencies manifests in folder for later verify.'
+                        ' Default folder is .conan_manifests, but can be changed')
+    parser.add_argument("--manifests-interactive", "-mi", const=default_manifest_folder,
+                        nargs="?",
+                        help='Install dependencies manifests in folder for later verify, '
+                        'asking user for confirmation. '
+                        'Default folder is .conan_manifests, but can be changed')
+    parser.add_argument("--verify", "-v", const=default_manifest_folder, nargs="?",
+                        help='Verify dependencies manifests against stored ones')
 
 
 def _add_common_install_arguments(parser, build_help):
@@ -934,37 +889,6 @@ def _add_common_install_arguments(parser, build_help):
     parser.add_argument("--build", "-b", action=Extender, nargs="*", help=build_help)
 
 
-def _get_tuples_list_from_extender_arg(items):
-    if not items:
-        return []
-    # Validate the pairs
-    for item in items:
-        chunks = item.split("=")
-        if len(chunks) != 2:
-            raise ConanException("Invalid input '%s', use 'name=value'" % item)
-    return [(item[0], item[1]) for item in [item.split("=") for item in items]]
-
-
-def _get_simple_and_package_tuples(items):
-    """Parse items like "thing:item=value or item2=value2 and returns a tuple list for
-    the simple items (name, value) and a dict for the package items
-    {package: [(item, value)...)], ...}
-    """
-
-    simple_items = []
-    package_items = defaultdict(list)
-    tuples = _get_tuples_list_from_extender_arg(items)
-    for name, value in tuples:
-        if ":" in name:  # Scoped items
-            tmp = name.split(":", 1)
-            ref_name = tmp[0]
-            name = tmp[1]
-            package_items[ref_name].append((name, value))
-        else:
-            simple_items.append((name, value))
-    return simple_items, package_items
-
-
 _help_build_policies = '''Optional, use it to choose if you want to build from sources:
 
         --build            Build all from sources, do not use binary packages.
@@ -973,16 +897,6 @@ _help_build_policies = '''Optional, use it to choose if you want to build from s
         --build=outdated   Build from code if the binary is not built with the current recipe or when missing binary package.
         --build=[pattern]  Build always these packages from source, but never build the others. Allows multiple --build parameters.
 '''
-
-
-def _get_env_values(env, package_env):
-    env_values = EnvValues()
-    for name, value in env:
-        env_values.add(name, EnvValues.load_value(value))
-    for package, data in package_env.items():
-        for name, value in data:
-            env_values.add(name, EnvValues.load_value(value), package)
-    return env_values
 
 
 def _get_reference(args):

--- a/conans/client/command_profile_args.py
+++ b/conans/client/command_profile_args.py
@@ -1,0 +1,74 @@
+from conans.model.profile import Profile
+from conans.errors import ConanException
+from collections import defaultdict, OrderedDict
+from conans.model.env_info import EnvValues
+from conans.model.options import OptionsValues
+from conans.model.scope import Scopes
+
+
+def profile_from_args(args, cwd, default_folder):
+    """ Return a Profile object, as the result of merging a potentially existing Profile
+    file and the args command-line arguments
+    """
+    file_profile = Profile.read_file(args.profile, cwd, default_folder)
+    args_profile = _profile_parse_args(args.settings, args.options, args.env, args.scope)
+
+    if file_profile:
+        file_profile.update(args_profile)
+        return file_profile
+    else:
+        return args_profile
+
+
+def _profile_parse_args(settings, options, envs, scopes):
+    """ return a Profile object result of parsing raw data
+    """
+    def _get_tuples_list_from_extender_arg(items):
+        if not items:
+            return []
+        # Validate the pairs
+        for item in items:
+            chunks = item.split("=")
+            if len(chunks) != 2:
+                raise ConanException("Invalid input '%s', use 'name=value'" % item)
+        return [(item[0], item[1]) for item in [item.split("=") for item in items]]
+
+    def _get_simple_and_package_tuples(items):
+        """Parse items like "thing:item=value or item2=value2 and returns a tuple list for
+        the simple items (name, value) and a dict for the package items
+        {package: [(item, value)...)], ...}
+        """
+        simple_items = []
+        package_items = defaultdict(list)
+        tuples = _get_tuples_list_from_extender_arg(items)
+        for name, value in tuples:
+            if ":" in name:  # Scoped items
+                tmp = name.split(":", 1)
+                ref_name = tmp[0]
+                name = tmp[1]
+                package_items[ref_name].append((name, value))
+            else:
+                simple_items.append((name, value))
+        return simple_items, package_items
+
+    def _get_env_values(env, package_env):
+        env_values = EnvValues()
+        for name, value in env:
+            env_values.add(name, EnvValues.load_value(value))
+        for package, data in package_env.items():
+            for name, value in data:
+                env_values.add(name, EnvValues.load_value(value), package)
+        return env_values
+
+    result = Profile()
+    options = _get_tuples_list_from_extender_arg(options)
+    result.options = OptionsValues(options)
+    env, package_env = _get_simple_and_package_tuples(envs)
+    env_values = _get_env_values(env, package_env)
+    result.env_values = env_values
+    settings, package_settings = _get_simple_and_package_tuples(settings)
+    result.settings = OrderedDict(settings)
+    for pkg, values in package_settings.items():
+        result.package_settings[pkg] = OrderedDict(values)
+    result.scopes = Scopes.from_list(scopes) if scopes else None
+    return result

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -13,7 +13,7 @@ from conans.model.env_info import unquote
 MIN_SERVER_COMPATIBLE_VERSION = '0.12.0'
 
 default_settings_yml = """os: [Windows, Linux, Macos, Android, iOS, FreeBSD, SunOS]
-arch: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8]
+arch: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8, sparc, sparcv9]
 compiler:
     sun-cc:
        version: ["5.10", "5.11", "5.12", "5.13", "5.14"]

--- a/conans/client/configure_environment.py
+++ b/conans/client/configure_environment.py
@@ -118,9 +118,9 @@ class ConfigureEnvironment(object):
             self.libcxx = None
 
     def _gcc_arch_flags(self):
-        if self.arch == "x86_64":
+        if self.arch == "x86_64" or self.arch == "sparcv9":
             return "-m64"
-        elif self.arch == "x86":
+        elif self.arch == "x86" or self.arch == "sparc":
             return "-m32"
         else:
             return "";
@@ -230,7 +230,6 @@ class ConfigureEnvironment(object):
     def compile_flags(self):
         if self.compiler == "gcc" or "clang" in str(self.compiler) or self.compiler == "sun-cc":
             flags = []
-            flags.extend("-l%s" % lib for lib in self._deps_cpp_info.libs)
             flags.append(self._gcc_arch_flags())
             flags.extend(self._deps_cpp_info.exelinkflags)
             flags.extend(self._deps_cpp_info.sharedlinkflags)
@@ -241,6 +240,7 @@ class ConfigureEnvironment(object):
             flags.extend('-D%s' % i for i in self._deps_cpp_info.defines)
             flags.extend('-I"%s"' % i for i in self._deps_cpp_info.include_paths)
             flags.extend('-L"%s"' % i for i in self._deps_cpp_info.lib_paths)
+            flags.extend("-l%s" % lib for lib in self._deps_cpp_info.libs)
             flags.extend(self._deps_cpp_info.cppflags)
             flags.extend(self._gcc_lib_flags())
 

--- a/conans/client/deps_builder.py
+++ b/conans/client/deps_builder.py
@@ -10,7 +10,6 @@ from conans.client.output import ScopedOutput
 import time
 from conans.util.log import logger
 from collections import defaultdict
-from conans.model.env_info import EnvValues
 
 
 class Node(namedtuple("Node", "conan_ref conanfile")):

--- a/conans/client/detect.py
+++ b/conans/client/detect.py
@@ -170,7 +170,8 @@ def _detect_os_arch(result, output):
                      'i686': 'x86',
                      'i86pc': 'x86',
                      'amd64': 'x86_64',
-                     'aarch64': 'armv8'}
+                     'aarch64': 'armv8',
+                     'sun4v': 'sparc'}
 
     result.append(("os", detected_os()))
     arch = architectures.get(platform.machine().lower(), platform.machine().lower())

--- a/conans/client/grapher.py
+++ b/conans/client/grapher.py
@@ -1,43 +1,163 @@
-import os
-from conans.model.ref import ConanFileReference
+from conans.util.files import save
+from conans.client.installer import build_id
+
 
 class ConanGrapher(object):
     def __init__(self, project_reference, deps_graph):
         self._deps_graph = deps_graph
         self._project_reference = project_reference
 
-    def graph(self, output_file):
-        graph_lines = []
-
-        graph_lines.append('digraph {\n')
+    def graph(self):
+        graph_lines = ['digraph {\n']
 
         for node in self._deps_graph.nodes:
-            ref = node.conan_ref
-
-            if ref is None:
-                ref = self._project_reference
-
+            ref = node.conan_ref or self._project_reference
             depends = self._deps_graph.neighbors(node)
-
             if depends:
-                graph_lines.append('    "%s" -> {' % str(ref))
-
-                for i, dep in enumerate(depends):
-                    graph_lines.append('"%s"' % str(dep.conan_ref))
-
-                    if i == len(depends) - 1:
-                        graph_lines.append('}\n')
-                    else:
-                        graph_lines.append(' ')
+                depends = " ".join('"%s"' % str(d.conan_ref) for d in depends)
+                graph_lines.append('    "%s" -> {%s}\n' % (str(ref), depends))
 
         graph_lines.append('}\n')
+        return ''.join(graph_lines)
 
-        graph_lines_string = ''.join(graph_lines)
+    def graph_file(self, output_filename):
+        save(output_filename, self.graph())
 
-        self.graph_file(graph_lines_string, output_file)
 
-    def graph_file(self, graph, output_filename):
-        output_file = os.path.join(os.getcwd(), output_filename)
+class ConanHTMLGrapher(object):
+    def __init__(self, project_reference, deps_graph):
+        self._deps_graph = deps_graph
+        self._project_reference = project_reference
 
-        with open(output_file, 'w') as f:
-            f.write(graph)
+    def graph_file(self, filename):
+        save(filename, self.graph())
+
+    def graph(self):
+        nodes = []
+        nodes_map = {}
+        graph_nodes = self._deps_graph.by_levels()
+        graph_nodes = reversed([n for level in graph_nodes for n in level])
+        for i, node in enumerate(graph_nodes):
+            ref, conanfile = node
+            nodes_map[node] = i
+            if ref:
+                label = "%s/%s" % (ref.name, ref.version)
+                fulllabel = [str(ref)]
+                fulllabel.append("")
+                fulllabel.append("id: %s" % conanfile.info.package_id())
+                fulllabel.append("build_id: %s" % build_id(conanfile))
+                if conanfile.url:
+                    fulllabel.append("url: %s" % conanfile.url)
+                if conanfile.license:
+                    fulllabel.append("license: %s" % conanfile.license)
+                if conanfile.author:
+                    fulllabel.append("author: %s" % conanfile.author)
+                fulllabel = r"\n".join(fulllabel)
+            else:
+                fulllabel = label = self._project_reference
+            nodes.append("{id: %d, label: '%s', shape: 'box', fulllabel: '%s'}"
+                         % (i, label, fulllabel))
+        nodes = ",\n".join(nodes)
+
+        edges = []
+        for node in self._deps_graph.nodes:
+            for node_to in self._deps_graph.neighbors(node):
+                src = nodes_map[node]
+                dst = nodes_map[node_to]
+                edges.append("{ from: %d, to: %d }" % (src, dst))
+        edges = ",\n".join(edges)
+
+        return self._template.replace("%NODES%", nodes).replace("%EDGES%", edges)
+
+    _template = """<html>
+
+<head>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/vis/4.18.1/vis.min.js"></script>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/vis/4.18.1/vis.min.css" rel="stylesheet" type="text/css" />
+</head>
+
+<body>
+  <script type="text/javascript">
+    function showhideclass(id) {
+      var elements = document.getElementsByClassName(id)
+      for (var i = 0; i < elements.length; i++) {
+        elements[i].style.display = (elements[i].style.display != 'none') ? 'none' : 'block';
+      }
+    }
+  </script>
+  <style>
+    @media print {
+      .noPrint {
+        display: none;
+      }
+    }
+  </style>
+  <div align="right">
+    <a href="javascript:showhideclass('controls')" class="noPrint">Show/hide controls.</a>
+  </div>
+  <div id="controls" class="controls"  style="display:none"></div>
+  <div id="mynetwork"></div>
+
+
+  <script type="text/javascript">
+    function showhideclass(id) {
+      var elements = document.getElementsByClassName(id)
+      for (var i = 0; i < elements.length; i++) {
+        elements[i].style.display = (elements[i].style.display != 'none') ? 'none' : 'block';
+      }
+    }
+    var nodes = new vis.DataSet([
+      %NODES%
+    ]);
+    var edges = new vis.DataSet([
+     %EDGES%
+    ]);
+    var container = document.getElementById('mynetwork');
+    var controls = document.getElementById('controls');
+    var data = {
+      nodes: nodes,
+      edges: edges
+    };
+    var options = {
+      autoResize: true,
+      locale: 'en',
+      edges: {
+        arrows: { to: {enabled: true}},
+        smooth: { enabled: false}
+      },
+      nodes: {
+          font: {'face': 'monospace', 'align': 'left'}
+      },
+      layout: {
+        "hierarchical": {
+          "enabled": true,
+          "sortMethod": "directed",
+          "direction": "UD",
+          nodeSpacing: 200
+        }
+      },
+      physics: {
+          enabled: false,
+      },
+      configure: {
+        enabled: true,
+        filter: 'layout',
+        showButton: false,
+        container: controls
+      }
+    };
+    var network = new vis.Network(container, data, options);
+    network.on( 'click', function(properties) {
+        var ids = properties.nodes;
+        var clickedNodes = nodes.get(ids);
+       for (var i = 0; i < clickedNodes.length; i++) {
+          var temp = clickedNodes[i].fulllabel;
+          clickedNodes[i].fulllabel =  clickedNodes[i].label;
+          clickedNodes[i].label = temp;
+          nodes.update(clickedNodes[i]);
+        }
+    });
+  </script>
+</body>
+</html>
+"""

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -35,6 +35,7 @@ class ConanFileLoader(object):
         self._settings = settings
         self._user_options = options
         self._scopes = scopes
+
         self._package_settings = package_settings
         self._env_values = env_values
 

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -188,7 +188,8 @@ class ConanManager(object):
 
     def info(self, reference, current_path, profile, remote=None,
              info=None, filename=None, update=False, check_updates=False,
-             build_order=None, build_mode=None, graph_filename=None, package_filter=None):
+             build_order=None, build_mode=None, graph_filename=None, package_filter=None,
+             show_paths=False):
         """ Fetch and build all dependencies for the given reference
         @param reference: ConanFileReference or path to user space conanfile
         @param current_path: where the output files will be saved
@@ -240,7 +241,7 @@ class ConanManager(object):
             Printer(self._user_io.out).print_info(deps_graph, project_reference,
                                                   info, registry, graph_updates_info,
                                                   remote, read_dates(deps_graph),
-                                                  self._client_cache, package_filter)
+                                                  self._client_cache, package_filter, show_paths)
 
     def install(self, reference, current_path, profile, remote=None,
                 build_mode=None, filename=None, update=False, check_updates=False,

--- a/conans/client/new.py
+++ b/conans/client/new.py
@@ -78,8 +78,9 @@ class {package_name}TestConan(ConanFile):
 
     def build(self):
         cmake = CMake(self.settings)
-        self.run('cmake "%s" %s' % (self.conanfile_directory, cmake.command_line))
-        self.run("cmake --build . %s" % cmake.build_config)
+        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is in "test_package"
+        cmake.configure(self, source_dir=self.conanfile_directory, build_dir="./")
+        cmake.build(self)
 
     def imports(self):
         self.copy("*.dll", "bin", "bin")

--- a/conans/client/printer.py
+++ b/conans/client/printer.py
@@ -65,7 +65,8 @@ class Printer(object):
                 self._out.writeln("    package_folder: %s" % path, Color.BRIGHT_GREEN)
 
     def print_info(self, deps_graph, project_reference, _info, registry, graph_updates_info=None,
-                   remote=None, node_times=None, path_resolver=None, package_filter=None):
+                   remote=None, node_times=None, path_resolver=None, package_filter=None,
+                   show_paths=False):
         """ Print the dependency information for a conan file
 
             Attributes:
@@ -112,7 +113,8 @@ class Printer(object):
                 bid = build_id(conan)
                 self._out.writeln("    BuildID: %s" % bid, Color.BRIGHT_GREEN)
 
-            self._print_paths(ref, conan, path_resolver, show)
+            if show_paths:
+                self._print_paths(ref, conan, path_resolver, show)
 
             if isinstance(ref, ConanFileReference) and show("remote"):
                 if reg_remote:

--- a/conans/client/remover.py
+++ b/conans/client/remover.py
@@ -75,34 +75,39 @@ class ConanRemover(object):
         self._client_cache = client_cache
         self._search_manager = search_manager
 
-    def remove(self, pattern, src=None, build_ids=None, package_ids_filter=None, force=False):
+    def remove(self, pattern, src=None, build_ids=None, package_ids_filter=None, force=False, packages_query=None):
         """ Remove local/remote conans, package folders, etc.
-        @param pattern: it could be OpenCV* or OpenCV
+        @param src: Remove src folder
+        @param pattern: it could be OpenCV* or OpenCV or a ConanFileReference
+        @param build_ids: Lists with ids or empty for all. (Its a filter)
         @param package_ids_filter: Lists with ids or empty for all. (Its a filter)
         @param force: if True, it will be deleted without requesting anything
+        @param packages_query: Only if src is a reference. Query settings and options
         """
-
         has_remote = self._remote_proxy._remote_name
-        if has_remote:
-            if build_ids is not None or src:
-                raise ConanException("Remotes don't have 'build' or 'src' folder, just packages")
-            search_info = self._remote_proxy.search(pattern)
-        else:
-            search_info = self._search_manager.search(pattern)
 
-        if not search_info:
-            self._user_io.out.warn("No package recipe reference matches with %s pattern" % pattern)
+        if has_remote and (build_ids is not None or src):
+            raise ConanException("Remotes don't have 'build' or 'src' folder, just packages")
+
+        conan_refs, package_ids = self._select_packages_to_remove(package_ids_filter, has_remote,
+                                                                  packages_query, pattern)
+
+        if not conan_refs:
+            if packages_query:
+                self._user_io.out.warn("No packages matching the query: %s" % packages_query)
+            else:
+                self._user_io.out.warn("No package recipe reference matches with '%s' pattern" % str(pattern))
             return
 
         deleted_refs = []
-        for conan_ref in search_info:
+        for conan_ref in conan_refs:
             assert(isinstance(conan_ref, ConanFileReference))
-            if self._ask_permission(conan_ref, src, build_ids, package_ids_filter, force):
+            if self._ask_permission(conan_ref, src, build_ids, package_ids, force):
                 if has_remote:
-                    if package_ids_filter is None:
+                    if package_ids is None:
                         self._remote_proxy.remove(conan_ref)
                     else:
-                        self._remote_proxy.remove_packages(conan_ref, package_ids_filter)
+                        self._remote_proxy.remove_packages(conan_ref, package_ids)
                 else:
                     deleted_refs.append(conan_ref)
                     remover = DiskRemover(self._client_cache)
@@ -110,9 +115,9 @@ class ConanRemover(object):
                         remover.remove_src(conan_ref)
                     if build_ids is not None:
                         remover.remove_builds(conan_ref, build_ids)
-                    if package_ids_filter is not None:
-                        remover.remove_packages(conan_ref, package_ids_filter)
-                    if not src and build_ids is None and package_ids_filter is None:
+                    if package_ids is not None:
+                        remover.remove_packages(conan_ref, package_ids)
+                    if not src and build_ids is None and package_ids is None:
                         remover.remove(conan_ref)
                         registry = self._remote_proxy.registry
                         registry.remove_ref(conan_ref, quiet=True)
@@ -120,7 +125,26 @@ class ConanRemover(object):
         if not has_remote:
             self._client_cache.delete_empty_dirs(deleted_refs)
 
+    def _select_packages_to_remove(self, package_ids, has_remote, packages_query, pattern):
+        if has_remote:
+            if not packages_query:
+                conan_refs = self._remote_proxy.search(pattern)
+            else:
+                package_ids = list(self._remote_proxy.search_packages(pattern, packages_query).keys())
+                conan_refs = [pattern] if package_ids else None
+        else:
+            if not packages_query:
+                conan_refs = self._search_manager.search(pattern)
+            else:
+                package_ids = list(self._search_manager.search_packages(pattern, packages_query).keys())
+                conan_refs = [pattern] if package_ids else None
+
+        return conan_refs, package_ids
+
     def _ask_permission(self, conan_ref, src, build_ids, package_ids_filter, force):
+        def stringlist(alist):
+            return ", ".join(['"%s"' % p for p in alist])
+
         if force:
             return True
         aux_str = []
@@ -128,12 +152,12 @@ class ConanRemover(object):
             aux_str.append(" src folder")
         if build_ids is not None:
             if build_ids:
-                aux_str.append(" %s builds" % build_ids)
+                aux_str.append(" %s builds" % stringlist(build_ids))
             else:
                 aux_str.append(" all builds")
         if package_ids_filter is not None:
             if package_ids_filter:
-                aux_str.append(" %s package" % package_ids_filter)
+                aux_str.append(" %s packages" % stringlist(package_ids_filter))
             else:  # All packages to remove, no filter
                 aux_str.append(" all packages")
         return self._user_io.request_boolean("Are you sure you want to delete%s from '%s'"

--- a/conans/client/require_resolver.py
+++ b/conans/client/require_resolver.py
@@ -40,7 +40,7 @@ class RequireResolver(object):
             ref = require.conan_reference
             resolved = self._resolve_version(version_range, [ref])
             if not resolved:
-                self._output.warn("Version range '%s' required by '%s' not valid for "
+                self._output.werror("Version range '%s' required by '%s' not valid for "
                                   "downstream requirement '%s'"
                                   % (version_range, base_conanref, str(ref)))
             else:

--- a/conans/model/profile.py
+++ b/conans/model/profile.py
@@ -4,6 +4,10 @@ from conans.model.scope import Scopes, _root
 from conans.errors import ConanException
 from collections import defaultdict
 from conans.model.env_info import EnvValues, unquote
+from conans.model.options import OptionsValues
+import os
+from conans.util.files import load, mkdir
+from conans.model.values import Values
 
 
 class Profile(object):
@@ -12,22 +16,64 @@ class Profile(object):
 
     def __init__(self):
         # Sections
-        self._settings = OrderedDict()
-        self._package_settings = defaultdict(OrderedDict)
+        self.settings = OrderedDict()
+        self.package_settings = defaultdict(OrderedDict)
         self.env_values = EnvValues()
         self.scopes = Scopes()
+        self.options = OptionsValues()
 
     @property
-    def package_settings(self):
-        return {package_name: list(settings.items()) for package_name, settings in self._package_settings.items()}
+    def settings_values(self):
+        return Values.from_list(list(self.settings.items()))
 
     @property
-    def settings(self):
-        return list(self._settings.items())
+    def package_settings_values(self):
+        result = {}
+        for pkg, settings in self.package_settings.items():
+            result[pkg] = list(settings.items())
+        return result
+
+    @staticmethod
+    def read_file(profile_name, cwd, default_folder):
+        """ Will look for "profile_name" in disk if profile_name is absolute path,
+        in current folder if path is relative or in the default folder otherwise.
+        return: a Profile object
+        """
+        if not profile_name:
+            return None
+
+        if os.path.isabs(profile_name):
+            profile_path = profile_name
+            folder = os.path.dirname(profile_name)
+        elif profile_name.startswith("."):  # relative path name
+            profile_path = os.path.abspath(os.path.join(cwd, profile_name))
+            folder = os.path.dirname(profile_path)
+        else:
+            folder = default_folder
+            if not os.path.exists(folder):
+                mkdir(folder)
+            profile_path = os.path.join(folder, profile_name)
+
+        try:
+            text = load(profile_path)
+        except Exception:
+            if os.path.exists(folder):
+                profiles = [name for name in os.listdir(folder) if not os.path.isdir(name)]
+            else:
+                profiles = []
+            current_profiles = ", ".join(profiles) or "[]"
+            raise ConanException("Specified profile '%s' doesn't exist.\nExisting profiles: "
+                                 "%s" % (profile_name, current_profiles))
+
+        try:
+            return Profile.loads(text)
+        except ConanException as exc:
+            raise ConanException("Error reading '%s' profile: %s" % (profile_name, exc))
 
     @staticmethod
     def loads(text):
-
+        """ Parse and return a Profile object from a text config like representation
+        """
         def get_package_name_value(item):
             '''Parse items like package:name=value or name=value'''
             package_name = None
@@ -42,7 +88,7 @@ class Profile(object):
 
         try:
             obj = Profile()
-            doc = ConfigParser(text, allowed_fields=["settings", "env", "scopes"])
+            doc = ConfigParser(text, allowed_fields=["settings", "env", "scopes", "options"])
 
             for setting in doc.settings.splitlines():
                 setting = setting.strip()
@@ -51,15 +97,18 @@ class Profile(object):
                         raise ConanException("Invalid setting line '%s'" % setting)
                     package_name, name, value = get_package_name_value(setting)
                     if package_name:
-                        obj._package_settings[package_name][name] = value
+                        obj.package_settings[package_name][name] = value
                     else:
-                        obj._settings[name] = value
+                        obj.settings[name] = value
 
             if doc.scopes:
                 obj.scopes = Scopes.from_list(doc.scopes.splitlines())
 
+            if doc.options:
+                obj.options = OptionsValues.loads(doc.options)
+
             obj.env_values = EnvValues.loads(doc.env)
-            obj._order()
+
             return obj
         except ConanException:
             raise
@@ -67,20 +116,15 @@ class Profile(object):
             raise ConanException("Error parsing the profile text file: %s" % str(exc))
 
     def dumps(self):
-        self._order()  # gets in order the settings
-
-        def dump_simple_items(items, result):
-            for name, value in items:
-                result.append("%s=%s" % (name, value))
-
-        def dump_package_items(items, result):
-            for package, values in items:
-                for name, value in values.items():
-                    result.append("%s:%s=%s" % (package, name, value))
-
         result = ["[settings]"]
-        dump_simple_items(self._settings.items(), result)
-        dump_package_items(self._package_settings.items(), result)
+        for name, value in self.settings.items():
+            result.append("%s=%s" % (name, value))
+        for package, values in self.package_settings.items():
+            for name, value in values.items():
+                result.append("%s:%s=%s" % (package, name, value))
+
+        result.append("[options]")
+        result.append(self.options.dumps())
 
         result.append("[scopes]")
         if self.scopes[_root].get("dev", None):
@@ -94,59 +138,27 @@ class Profile(object):
 
         return "\n".join(result).replace("\n\n", "\n")
 
+    def update(self, other):
+        self.update_settings(other.settings)
+        self.update_package_settings(other.package_settings)
+        self.update_scopes(other.scopes)
+        # this is the opposite
+        other.env_values.update(self.env_values)
+        self.env_values = other.env_values
+        self.options.update(other.options)
+
     def update_settings(self, new_settings):
         '''Mix the specified settings with the current profile.
         Specified settings are prioritized to profile'''
         # apply the current profile
         if new_settings:
-            self._settings.update(new_settings)
-            self._order()
+            self.settings.update(new_settings)
 
     def update_package_settings(self, package_settings):
         '''Mix the specified package settings with the specified profile.
         Specified package settings are prioritized to profile'''
-        for package_name, settings in self._package_settings.items():
-            if package_name in package_settings:
-                settings.update(dict(package_settings[package_name]))
-
-        # The rest of new packages settings
         for package_name, settings in package_settings.items():
-            if package_name not in self._package_settings:
-                self._package_settings[package_name].update(dict(settings))
-
-        self._order()
-
-    def _mix_env_with_new(self, env_dict, new_env):
-
-        res_env = OrderedDict()
-        for name, value in new_env:
-            if name in env_dict:
-                del env_dict[name]
-            res_env[name] = value  # Insert first in the result
-
-        for name, value in env_dict.items():
-            res_env[name] = value  # Insert the rest of env vars at the end
-
-        return res_env
-
-    def update_packages_env(self, new_packages_env):
-        '''Priorize new_packages_env to override the current package_env'''
-        if not new_packages_env:
-            return
-        res_env = defaultdict(OrderedDict)
-
-        # Mix the common packages env
-        for package, env_vars in self._package_env.items():
-            new_env = new_packages_env.get(package, [])
-            res_env[package] = self._mix_env_with_new(env_vars, new_env)
-
-        # The rest of new packages env variables
-        for package, env_vars in new_packages_env.items():
-            if package not in res_env:
-                for name, value in env_vars:
-                    res_env[package][name] = value  # Insert the rest of env vars at the end
-
-        self._package_env = res_env
+            self.package_settings[package_name].update(settings)
 
     def update_scopes(self, new_scopes):
         '''Mix the specified settings with the current profile.
@@ -154,23 +166,3 @@ class Profile(object):
         # apply the current profile
         if new_scopes:
             self.scopes.update(new_scopes)
-            self._order()
-
-    def _order(self):
-
-        def order_single_settings(settings):
-            ret = OrderedDict()
-            # Insert in a good order
-            for func in [lambda x: "." not in x,  # First the principal settings
-                         lambda x: "." in x]:
-                for name, value in settings.items():
-                    if func(name):
-                        ret[name] = value
-            return ret
-
-        # Order global settings
-        self._settings = order_single_settings(self._settings)
-
-        # Order package settings
-        for package_name, settings in self._package_settings.items():
-            self._package_settings[package_name] = order_single_settings(settings)

--- a/conans/search/search.py
+++ b/conans/search/search.py
@@ -122,8 +122,11 @@ class DiskSearchManager(SearchManagerABC):
         self._adapter = disk_search_adapter
 
     def search(self, pattern=None, ignorecase=True):
+
         # Conan references in main storage
         if pattern:
+            if isinstance(pattern, ConanFileReference):
+                pattern = str(pattern)
             pattern = translate(pattern)
             pattern = re.compile(pattern, re.IGNORECASE) if ignorecase else re.compile(pattern)
 

--- a/conans/test/command/info_folders_test.py
+++ b/conans/test/command/info_folders_test.py
@@ -51,7 +51,7 @@ class InfoFoldersTest(unittest.TestCase):
         client = TestClient()
         client.save({CONANFILE: conanfile_py})
         client.run("export %s" % self.user_channel)
-        client.run("info %s" % (self.conan_ref))
+        client.run("info --paths %s" % (self.conan_ref))
         base_path = os.path.join("MyPackage", "0.1.0", "myUser", "testing")
         output = client.user_io.out
         self.assertIn(os.path.join(base_path, "export"), output)
@@ -65,7 +65,7 @@ class InfoFoldersTest(unittest.TestCase):
         self._prepare_deps(client)
 
         for ref in [self.conan_ref2, ""]:
-            client.run("info %s" % (ref))
+            client.run("info --paths %s" % (ref))
             output = client.user_io.out
 
             base_path = os.path.join("MyPackage", "0.1.0", "myUser", "testing")
@@ -79,7 +79,7 @@ class InfoFoldersTest(unittest.TestCase):
     def test_deps_specific_information(self):
         client = TestClient()
         self._prepare_deps(client)
-        client.run("info --only package_folder --package_filter MyPackage/*")
+        client.run("info --paths --only package_folder --package_filter MyPackage/*")
         output = client.user_io.out
 
         base_path = os.path.join("MyPackage", "0.1.0", "myUser", "testing")
@@ -87,7 +87,7 @@ class InfoFoldersTest(unittest.TestCase):
         self.assertNotIn("build", output)
         self.assertNotIn("MyPackage2", output)
 
-        client.run("info --only package_folder --package_filter MyPackage*")
+        client.run("info --paths --only package_folder --package_filter MyPackage*")
         output = client.user_io.out
 
         base_path = os.path.join("MyPackage", "0.1.0", "myUser", "testing")
@@ -101,7 +101,7 @@ class InfoFoldersTest(unittest.TestCase):
         client = TestClient()
         client.save({CONANFILE: conanfile_py})
         client.run("export %s" % self.user_channel)
-        client.run("info --only=build_folder %s" % (self.conan_ref))
+        client.run("info --paths --only=build_folder %s" % (self.conan_ref))
         base_path = os.path.join("MyPackage", "0.1.0", "myUser", "testing")
         output = client.user_io.out
         self.assertNotIn("export", output)
@@ -117,7 +117,7 @@ class InfoFoldersTest(unittest.TestCase):
                 client = TestClient(base_folder=folder)
                 client.save({CONANFILE: conanfile_py.replace("False", "True")})
                 client.run("export %s" % self.user_channel)
-                client.run("info %s" % (self.conan_ref))
+                client.run("info --paths %s" % (self.conan_ref))
                 base_path = os.path.join("MyPackage", "0.1.0", "myUser", "testing")
                 output = client.user_io.out
                 self.assertIn(os.path.join(base_path, "export"), output)

--- a/conans/test/command/info_folders_test.py
+++ b/conans/test/command/info_folders_test.py
@@ -1,19 +1,22 @@
 import unittest
-import os, re
+import os
+import platform
 
 from conans import tools
 from conans.test.tools import TestClient
 from conans.test.utils.test_files import temp_folder
 from conans.paths import CONANFILE
-import platform
+from conans.model.ref import ConanFileReference, PackageReference
+import re
 
-short_path_file = """
+
+conanfile_py = """
 from conans import ConanFile
 
 class AConan(ConanFile):
     name = "MyPackage"
     version = "0.1.0"
-    short_paths=True
+    short_paths=False
 """
 
 with_deps_path_file = """
@@ -33,124 +36,116 @@ MyPackage2/0.2.0@myUser/testing
 
 class InfoFoldersTest(unittest.TestCase):
     def setUp(self):
-        self.settings = ("-s os=Windows -s compiler='Visual Studio' -s compiler.version=12 "
-                         "-s arch=x86 -s compiler.runtime=MD")
-
-        self.userChannel = "myUser/testing"
-        self.conan_ref = "MyPackage/0.1.0@%s" % self.userChannel
-        self.conan_ref2 = "MyPackage2/0.2.0@%s" % self.userChannel
+        self.user_channel = "myUser/testing"
+        self.conan_ref = "MyPackage/0.1.0@%s" % self.user_channel
+        self.conan_ref2 = "MyPackage2/0.2.0@%s" % self.user_channel
 
     def _prepare_deps(self, client):
-        client.run("new %s" % self.conan_ref)
-        client.run("export %s" % self.userChannel)
+        client.save({CONANFILE: conanfile_py})
+        client.run("export %s" % self.user_channel)
         client.save({CONANFILE: with_deps_path_file}, clean_first=True)
-        client.run("export %s" % self.userChannel)
+        client.run("export %s" % self.user_channel)
         client.save({'conanfile.txt': deps_txt_file}, clean_first=True)
 
     def test_basic(self):
         client = TestClient()
-        client.run("new %s" % self.conan_ref)
-        client.run("export %s" % self.userChannel)
-        client.run("info %s %s" % (self.conan_ref, self.settings))
-        basePath = os.path.join("MyPackage", "0.1.0", "myUser", "testing");
-        output = client.user_io.out;
-        self.assertIn(os.path.join(basePath, "export"), output)
-        self.assertIn(os.path.join(basePath, "source"), output)
-        id = re.search('ID:\s*([a-z0-9]*)', str(client.user_io.out)).group(1);
-        self.assertIn(os.path.join(basePath, "build", id), output)
-        self.assertIn(os.path.join(basePath, "package", id), output)
+        client.save({CONANFILE: conanfile_py})
+        client.run("export %s" % self.user_channel)
+        client.run("info %s" % (self.conan_ref))
+        base_path = os.path.join("MyPackage", "0.1.0", "myUser", "testing")
+        output = client.user_io.out
+        self.assertIn(os.path.join(base_path, "export"), output)
+        self.assertIn(os.path.join(base_path, "source"), output)
+        id_ = "5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9"
+        self.assertIn(os.path.join(base_path, "build", id_), output)
+        self.assertIn(os.path.join(base_path, "package", id_), output)
 
     def test_deps_basic(self):
         client = TestClient()
         self._prepare_deps(client)
-        client.run("info %s %s" % (self.conan_ref2, self.settings))
-        output = client.user_io.out;
 
-        basePath = os.path.join("MyPackage", "0.1.0", "myUser", "testing");
-        self.assertIn(os.path.join(basePath, "export"), output)
-        self.assertIn(os.path.join(basePath, "source"), output)
+        for ref in [self.conan_ref2, ""]:
+            client.run("info %s" % (ref))
+            output = client.user_io.out
 
-        basePath = os.path.join("MyPackage2", "0.2.0", "myUser", "testing");
-        self.assertIn(os.path.join(basePath, "export"), output)
-        self.assertIn(os.path.join(basePath, "source"), output)
+            base_path = os.path.join("MyPackage", "0.1.0", "myUser", "testing")
+            self.assertIn(os.path.join(base_path, "export"), output)
+            self.assertIn(os.path.join(base_path, "source"), output)
 
-    def test_deps_conanfile_txt(self):
-        client = TestClient()
-        self._prepare_deps(client)
-        client.run("info %s" % (self.settings))
-        output = client.user_io.out;
-
-        basePath = os.path.join("MyPackage", "0.1.0", "myUser", "testing");
-        self.assertIn(os.path.join(basePath, "export"), output)
-        self.assertIn(os.path.join(basePath, "source"), output)
-
-        basePath = os.path.join("MyPackage2", "0.2.0", "myUser", "testing");
-        self.assertIn(os.path.join(basePath, "export"), output)
-        self.assertIn(os.path.join(basePath, "source"), output)
+            base_path = os.path.join("MyPackage2", "0.2.0", "myUser", "testing")
+            self.assertIn(os.path.join(base_path, "export"), output)
+            self.assertIn(os.path.join(base_path, "source"), output)
 
     def test_deps_specific_information(self):
         client = TestClient()
         self._prepare_deps(client)
-        client.run("info --only package_folder --package_filter MyPackage/* %s" % (self.settings))
-        output = client.user_io.out;
+        client.run("info --only package_folder --package_filter MyPackage/*")
+        output = client.user_io.out
 
-        basePath = os.path.join("MyPackage", "0.1.0", "myUser", "testing");
-        self.assertIn(os.path.join(basePath, "package"), output)
-        self.assertNotIn(os.path.join(basePath, "build"), output)
+        base_path = os.path.join("MyPackage", "0.1.0", "myUser", "testing")
+        self.assertIn(os.path.join(base_path, "package"), output)
+        self.assertNotIn("build", output)
+        self.assertNotIn("MyPackage2", output)
 
-        basePath = os.path.join("MyPackage2", "0.2.0", "myUser", "testing");
-        self.assertNotIn(os.path.join(basePath, "package"), output)
+        client.run("info --only package_folder --package_filter MyPackage*")
+        output = client.user_io.out
 
-        client.run("info --only package_folder --package_filter MyPackage* %s" % (self.settings))
-        output = client.user_io.out;
+        base_path = os.path.join("MyPackage", "0.1.0", "myUser", "testing")
+        self.assertIn(os.path.join(base_path, "package"), output)
+        self.assertNotIn("build", output)
 
-        basePath = os.path.join("MyPackage", "0.1.0", "myUser", "testing");
-        self.assertIn(os.path.join(basePath, "package"), output)
-        self.assertNotIn(os.path.join(basePath, "build"), output)
-
-        basePath = os.path.join("MyPackage2", "0.2.0", "myUser", "testing");
-        self.assertIn(os.path.join(basePath, "package"), output)
-
+        base_path = os.path.join("MyPackage2", "0.2.0", "myUser", "testing")
+        self.assertIn(os.path.join(base_path, "package"), output)
 
     def test_single_field(self):
         client = TestClient()
-        client.run("new %s" % self.conan_ref)
-        client.run("export %s" % self.userChannel)
-        client.run("info --only=build_folder %s %s" % (self.conan_ref, self.settings))
-        basePath = os.path.join("MyPackage", "0.1.0", "myUser", "testing");
-        output = client.user_io.out;
-        self.assertNotIn(os.path.join(basePath, "export"), output)
-        self.assertNotIn(os.path.join(basePath, "source"), output)
-        self.assertIn(os.path.join(basePath, "build"), output)
-        self.assertNotIn(os.path.join(basePath, "package"), output)
+        client.save({CONANFILE: conanfile_py})
+        client.run("export %s" % self.user_channel)
+        client.run("info --only=build_folder %s" % (self.conan_ref))
+        base_path = os.path.join("MyPackage", "0.1.0", "myUser", "testing")
+        output = client.user_io.out
+        self.assertNotIn("export", output)
+        self.assertNotIn("source", output)
+        self.assertIn(os.path.join(base_path, "build"), output)
+        self.assertNotIn("package", output)
 
     def test_short_paths(self):
         if platform.system() == "Windows":
-            folder = temp_folder(False);
-            short_folder = os.path.join(folder, ".cn");
+            folder = temp_folder(False)
+            short_folder = os.path.join(folder, ".cn")
             with tools.environment_append({"CONAN_USER_HOME_SHORT": short_folder}):
                 client = TestClient(base_folder=folder)
-                client.save({CONANFILE: short_path_file})
-                client.run("export %s" % self.userChannel)
-                client.run("info %s %s" % (self.conan_ref, self.settings))
-                basePath = os.path.join("MyPackage", "0.1.0", "myUser", "testing");
-                output = client.user_io.out;
-                self.assertIn(os.path.join(basePath, "export"), output)
-                self.assertNotIn(os.path.join(basePath, "source"), output)
-                self.assertNotIn(os.path.join(basePath, "build"), output)
-                self.assertNotIn(os.path.join(basePath, "package"), output)
+                client.save({CONANFILE: conanfile_py.replace("False", "True")})
+                client.run("export %s" % self.user_channel)
+                client.run("info %s" % (self.conan_ref))
+                base_path = os.path.join("MyPackage", "0.1.0", "myUser", "testing")
+                output = client.user_io.out
+                self.assertIn(os.path.join(base_path, "export"), output)
+                self.assertNotIn(os.path.join(base_path, "source"), output)
+                self.assertNotIn(os.path.join(base_path, "build"), output)
+                self.assertNotIn(os.path.join(base_path, "package"), output)
 
-                self.assertIn("sourceFolder: %s" % short_folder, output)
-                self.assertIn("buildFolder: %s" % short_folder, output)
-                self.assertIn("packageFolder: %s" % short_folder, output)
+                self.assertIn("source_folder: %s" % short_folder, output)
+                self.assertIn("build_folder: %s" % short_folder, output)
+                self.assertIn("package_folder: %s" % short_folder, output)
+
+                # Ensure that the inner folders are not created (that could affect
+                # pkg creation flow
+                ref = ConanFileReference.loads(self.conan_ref)
+                id_ = re.search('ID:\s*([a-z0-9]*)', str(client.user_io.out)).group(1)
+                pkg_ref = PackageReference(ref, id_)
+                for path in (client.client_cache.source(ref, True),
+                             client.client_cache.build(pkg_ref, True),
+                             client.client_cache.package(pkg_ref, True)):
+                    self.assertFalse(os.path.exists(path))
+                    self.assertTrue(os.path.exists(os.path.dirname(path)))
 
     def test_direct_conanfile(self):
         client = TestClient()
-        client.run("new %s" % self.conan_ref)
-        client.run("info %s" % (self.settings))
-        basePath = os.path.join("MyPackage", "0.1.0", "myUser", "testing");
-        output = client.user_io.out;
-        self.assertNotIn("exportFolder", output)
-        self.assertNotIn("sourceFolder", output)
-        self.assertNotIn("buildFolder", output)
-        self.assertNotIn("packageFolder", output)
+        client.save({CONANFILE: conanfile_py})
+        client.run("info")
+        output = client.user_io.out
+        self.assertNotIn("export_folder", output)
+        self.assertNotIn("source_folder", output)
+        self.assertNotIn("build_folder", output)
+        self.assertNotIn("package_folder", output)

--- a/conans/test/command/info_test.py
+++ b/conans/test/command/info_test.py
@@ -6,6 +6,7 @@ from conans.test.utils.cpp_test_files import cpp_hello_conan_files
 from conans.paths import CONANFILE
 from conans.model.ref import ConanFileReference
 import textwrap
+from conans.util.files import load
 
 
 class InfoTest(unittest.TestCase):
@@ -97,26 +98,53 @@ class InfoTest(unittest.TestCase):
         def check_file(dot_file):
             with open(dot_file) as dot_file_contents:
                 lines = dot_file_contents.readlines()
-                self.assertEqual(lines[0], "digraph {\n");
+                self.assertEqual(lines[0], "digraph {\n")
                 for line in lines[1:-1]:
                     check_digraph_line(line)
-                self.assertEqual(lines[-1], "}\n");
+                self.assertEqual(lines[-1], "}\n")
 
         create_export(test_deps, "Hello0")
 
-        node_regex = re.compile(r'"([^"]+)"');
+        node_regex = re.compile(r'"([^"]+)"')
         dot_regex = re.compile(r'^\s+"[^"]+" -> {"[^"]+"( "[^"]+")*}$')
 
         # default case - file will be named graph.dot
-        self.client.run("info --graph")
-        dot_file = os.path.join(self.client.current_folder, "graph.dot")
-        check_file(dot_file)
+        error = self.client.run("info --graph", ignore_error=True)
+        self.assertTrue(error)
 
         # arbitrary case - file will be named according to argument
         arg_filename = "test.dot"
         self.client.run("info --graph=%s" % arg_filename)
         dot_file = os.path.join(self.client.current_folder, arg_filename)
         check_file(dot_file)
+
+    def graph_html_test(self):
+        self.client = TestClient()
+
+        test_deps = {
+            "Hello0": ["Hello1"],
+            "Hello1": [],
+        }
+
+        def create_export(test_deps, name):
+            deps = test_deps[name]
+            for dep in deps:
+                create_export(test_deps, dep)
+
+            expanded_deps = ["%s/0.1@lasote/stable" % dep for dep in deps]
+            export = False if name == "Hello0" else True
+            self._create(name, "0.1", expanded_deps, export=export)
+
+        create_export(test_deps, "Hello0")
+
+        # arbitrary case - file will be named according to argument
+        arg_filename = "test.html"
+        self.client.run("info --graph=%s" % arg_filename)
+        arg_filename = os.path.join(self.client.current_folder, arg_filename)
+        html = load(arg_filename)
+        self.assertIn("<body>", html)
+        self.assertIn("{ from: 0, to: 1 }", html)
+        self.assertIn("id: 0, label: 'Hello0/0.1@PROJECT'", html)
 
     def only_names_test(self):
         self.client = TestClient()
@@ -174,10 +202,10 @@ class InfoTest(unittest.TestCase):
                               if not line.strip().startswith("Creation date") and
                               not line.strip().startswith("ID") and
                               not line.strip().startswith("BuildID") and
-                              not line.strip().startswith("exportFolder") and
-                              not line.strip().startswith("buildFolder") and
-                              not line.strip().startswith("sourceFolder") and
-                              not line.strip().startswith("packageFolder")])
+                              not line.strip().startswith("export_folder") and
+                              not line.strip().startswith("build_folder") and
+                              not line.strip().startswith("source_folder") and
+                              not line.strip().startswith("package_folder")])
 
         # The timestamp is variable so we can't check the equality
         self.assertIn(expected_output, clean_output(self.client.user_io.out))

--- a/conans/test/command/install_test.py
+++ b/conans/test/command/install_test.py
@@ -232,13 +232,9 @@ class InstallTest(unittest.TestCase):
         self.assertIn("Hello0/0.1@lasote/stable:2e38bbc2c3ef1425197c8e2ffa8532894c347d26",
                       conan_info.full_requires.dumps())
 
-    def warn_bad_os_test(self):
+    def cross_platform_msg_test(self):
         bad_os = "Linux" if platform.system() != "Linux" else "Macos"
-        message = "You are building this package with settings.os='%s" % bad_os
+        message = "Cross-platform from '%s' to '%s'" % (detected_os(), bad_os)
         self._create("Hello0", "0.1")
         self.client.run("install Hello0/0.1@lasote/stable -s os=%s" % bad_os, ignore_error=True)
         self.assertIn(message, self.client.user_io.out)
-
-        self.client.run("install Hello0/0.1@lasote/stable -s os=%s" % detected_os(),
-                        ignore_error=True)
-        self.assertNotIn("You are building this package with settings.os", self.client.user_io.out)

--- a/conans/test/compile_helpers_test.py
+++ b/conans/test/compile_helpers_test.py
@@ -23,7 +23,7 @@ class MockCompiler(object):
         self.libcxx = libcxx
         self.version = version
 
-    def __repr__(self, *args, **kwargs):
+    def __repr__(self, *args, **kwargs):  # @UnusedVariable
         return self.name
 
 
@@ -137,86 +137,105 @@ class CompileHelpersTest(unittest.TestCase):
         linux_s = MockSettings("Release", os="Linux", arch="x86",
                                compiler_name="gcc", libcxx="libstdc++", version="4.9")
         env = ConfigureEnvironment(MockConanfile(linux_s))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m32 -framework thing -framework '
+        self.assertEquals(env.compile_flags, '-m32 -framework thing -framework '
                                              'thing2 -s -DNDEBUG -DMYDEF1 -DMYDEF2 '
                                              '-I"path/to/includes/lib1" -I"path/to/includes/lib2" '
-                                             '-L"path/to/lib1" -L"path/to/lib2" cppflag1 '
+                                             '-L"path/to/lib1" -L"path/to/lib2" -llib1 -llib2 cppflag1 '
                                              '-D_GLIBCXX_USE_CXX11_ABI=0')
 
         linux_s_11 = MockSettings("Debug", os="Linux", arch="x86_64",
                                   compiler_name="gcc", libcxx="libstdc++11", version="4.9")
         env = ConfigureEnvironment(MockConanfile(linux_s_11))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m64 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 '
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 '
                                              '-D_GLIBCXX_USE_CXX11_ABI=1')
 
         linux_s_clang_std = MockSettings("Debug", os="Linux", arch="x86_64",
                                          compiler_name="clang", libcxx="libstdc", version="4.9")
         env = ConfigureEnvironment(MockConanfile(linux_s_clang_std))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m64 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -stdlib=libstdc++')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 '
+                                             '-stdlib=libstdc++')
 
         linux_s_clang = MockSettings("Debug", os="Linux", arch="x86_64",
                                      compiler_name="clang", libcxx="libc++", version="4.9")
         env = ConfigureEnvironment(MockConanfile(linux_s_clang))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m64 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -stdlib=libc++')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 '
+                                             '-stdlib=libc++')
 
         freebsd_s_clang_32 = MockSettings("Debug", os="FreeBSD", arch="x86",
                                           compiler_name="clang", libcxx="libc++", version="3.8")
         env = ConfigureEnvironment(MockConanfile(freebsd_s_clang_32))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m32 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m32 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -stdlib=libc++')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 '
+                                             '-stdlib=libc++')
 
         freebsd_s_clang_64 = MockSettings("Debug", os="FreeBSD", arch="x86_64",
                                           compiler_name="clang", libcxx="libc++", version="3.8")
         env = ConfigureEnvironment(MockConanfile(freebsd_s_clang_64))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m64 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -stdlib=libc++')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 -stdlib=libc++')
 
         solaris_s_sun_cc_32 = MockSettings("Debug", os="SunOS", arch="x86",
                                            compiler_name="sun-cc", libcxx="libCstd", version="5.10")
         env = ConfigureEnvironment(MockConanfile(solaris_s_sun_cc_32))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m32 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m32 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -library=Cstd')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 -library=Cstd')
 
         solaris_s_sun_cc_64 = MockSettings("Debug", os="SunOS", arch="x86_64",
                                            compiler_name="sun-cc", libcxx="libCstd", version="5.10")
         env = ConfigureEnvironment(MockConanfile(solaris_s_sun_cc_64))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m64 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -library=Cstd')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 -library=Cstd')
 
         solaris_s_sun_cc_stlport = MockSettings("Debug", os="SunOS", arch="x86_64",
                                                 compiler_name="sun-cc", libcxx="libstlport",
                                                 version="5.10")
         env = ConfigureEnvironment(MockConanfile(solaris_s_sun_cc_stlport))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m64 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -library=stlport4')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 -library=stlport4')
 
         solaris_s_sun_cc_stdcxx = MockSettings("Debug", os="SunOS", arch="x86_64",
                                                compiler_name="sun-cc", libcxx="libstdcxx",
                                                version="5.10")
         env = ConfigureEnvironment(MockConanfile(solaris_s_sun_cc_stdcxx))
-        self.assertEquals(env.compile_flags, '-llib1 -llib2 -m64 -framework thing -framework thing2'
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
                                              ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
                                              '-I"path/to/includes/lib2" -L"path/to/lib1" '
-                                             '-L"path/to/lib2" cppflag1 -library=stdcxx4')
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 -library=stdcxx4')
+
+        solaris_s_sun_cc_sparc = MockSettings("Debug", os="SunOS", arch="sparc",
+                                              compiler_name="sun-cc", libcxx="libCstd", version="5.10")
+        env = ConfigureEnvironment(MockConanfile(solaris_s_sun_cc_sparc))
+        self.assertEquals(env.compile_flags, '-m32 -framework thing -framework thing2'
+                                             ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
+                                             '-I"path/to/includes/lib2" -L"path/to/lib1" '
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 -library=Cstd')
+
+        solaris_s_sun_cc_sparcv9 = MockSettings("Debug", os="SunOS", arch="sparcv9",
+                                                compiler_name="sun-cc", libcxx="libCstd", version="5.10")
+        env = ConfigureEnvironment(MockConanfile(solaris_s_sun_cc_sparcv9))
+        self.assertEquals(env.compile_flags, '-m64 -framework thing -framework thing2'
+                                             ' -g -DMYDEF1 -DMYDEF2 -I"path/to/includes/lib1" '
+                                             '-I"path/to/includes/lib2" -L"path/to/lib1" '
+                                             '-L"path/to/lib2" -llib1 -llib2 cppflag1 -library=Cstd')
 
     def configure_environment_test(self):
         win_settings = MockSettings("Release", os="Windows", arch="x86",
@@ -302,7 +321,7 @@ class CompileHelpersTest(unittest.TestCase):
                                             '"path/to/includes/lib2"')
 
         freebsd_settings = MockSettings("Release", os="FreeBSD", arch="x86",
-                                         compiler_name="clang", libcxx="libc++", version="3.8")
+                                        compiler_name="clang", libcxx="libc++", version="3.8")
         env = ConfigureEnvironment(MockConanfile(freebsd_settings))
         self.assertEquals(env.command_line, 'env LIBS="-llib1 -llib2" LDFLAGS="-Lpath/to/lib1 '
                                             '-Lpath/to/lib2 -m32 -framework thing -framework thing2 $LDFLAGS" '
@@ -329,9 +348,22 @@ class CompileHelpersTest(unittest.TestCase):
                                             'CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:"path/to/includes/lib1":'
                                             '"path/to/includes/lib2"')
 
+        solaris_sparc_settings = MockSettings("Release", os="SunOS", arch="sparc",
+                                              compiler_name="sun-cc", libcxx="libstlport", version="5.10")
+        env = ConfigureEnvironment(MockConanfile(solaris_sparc_settings))
+        self.assertEquals(env.command_line, 'env LIBS="-llib1 -llib2" LDFLAGS="-Lpath/to/lib1 '
+                                            '-Lpath/to/lib2 -m32 -framework thing -framework thing2 $LDFLAGS" '
+                                            'CFLAGS="$CFLAGS -m32 cflag1 -DNDEBUG '
+                                            '-Ipath/to/includes/lib1 -Ipath/to/includes/lib2 -DMYDEF1 -DMYDEF2" '
+                                            'CPPFLAGS="$CPPFLAGS -m32 cppflag1 -library=stlport4 -DNDEBUG '
+                                            '-Ipath/to/includes/lib1 -Ipath/to/includes/lib2 -DMYDEF1 -DMYDEF2" '
+                                            'C_INCLUDE_PATH=$C_INCLUDE_PATH:"path/to/includes/lib1":'
+                                            '"path/to/includes/lib2" '
+                                            'CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:"path/to/includes/lib1":'
+                                            '"path/to/includes/lib2"')
 
         # Not supported yet
-        win_gcc = MockSettings("Release", os="Windows", arch="x86", 
+        win_gcc = MockSettings("Release", os="Windows", arch="x86",
                                compiler_name="gcc", libcxx=None, version="4.9")
         env = ConfigureEnvironment(MockConanfile(win_gcc))
         self.assertEquals(env.command_line_env, 'call _conan_env.bat')
@@ -448,4 +480,4 @@ class ProfilesEnvironmentTest(unittest.TestCase):
             profile.scopes = Scopes.from_list(["%s=%s" % (key, value) for key, value in scopes.items()])
         for varname, value in env.items():
             profile.env_values.add(varname, value)
-        save(self.client.client_cache.profile_path(name), profile.dumps())
+        save(os.path.join(self.client.client_cache.profiles_path, name), profile.dumps())

--- a/conans/test/files_test.py
+++ b/conans/test/files_test.py
@@ -78,7 +78,7 @@ class FileCopierTest(unittest.TestCase):
         folder2 = temp_folder()
         copier = FileCopier(folder1, folder2)
         copier("*.txt", excludes="*Test*.txt")
-        self.assertEqual(['MyLib.txt', 'MyLibImpl.txt'], os.listdir(folder2))
+        self.assertEqual(set(['MyLib.txt', 'MyLibImpl.txt']), set(os.listdir(folder2)))
 
         folder2 = temp_folder()
         copier = FileCopier(folder1, folder2)

--- a/conans/test/integration/basic_build_test.py
+++ b/conans/test/integration/basic_build_test.py
@@ -46,6 +46,8 @@ class BasicBuildTest(unittest.TestCase):
 
     def build_default_test(self):
         "build default (gcc in nix, VS in win)"
+        if platform.system() == "SunOS":
+            return  # If is using sun-cc the gcc generator doesn't work
         for pure_c in (False, True):
             for cmd, lang, static in [("install", 0, True),
                                       ("install -o language=1", 1, True),

--- a/conans/test/integration/build_environment_test.py
+++ b/conans/test/integration/build_environment_test.py
@@ -64,6 +64,8 @@ int main(){
 class BuildEnvironmenTest(unittest.TestCase):
 
     def test_gcc_and_environment(self):
+        if platform.system() == "SunOS":
+            return  # If is using sun-cc the gcc generator doesn't work
 
         # CREATE A DUMMY LIBRARY WITH GCC (could be generated with other build system)
         client = TestClient()

--- a/conans/test/integration/diamond_test.py
+++ b/conans/test/integration/diamond_test.py
@@ -72,6 +72,10 @@ class DiamondTest(unittest.TestCase):
         self._diamond_test(install=install, use_cmake=False)
 
     def _diamond_test(self, install="install", use_cmake=True, cmake_targets=False):
+
+        if not use_cmake and platform.system() == "SunOS":
+            return  # If is using sun-cc the gcc generator doesn't work
+
         self._export_upload("Hello0", "0.1", use_cmake=use_cmake, cmake_targets=cmake_targets)
         self._export_upload("Hello1", "0.1", ["Hello0/0.1@lasote/stable"], use_cmake=use_cmake,
                             cmake_targets=cmake_targets)

--- a/conans/test/integration/profile_test.py
+++ b/conans/test/integration/profile_test.py
@@ -47,7 +47,8 @@ class ProfileTest(unittest.TestCase):
         profile = '''
         [settings
         '''
-        save(self.client.client_cache.profile_path("clang"), profile)
+        clang_profile_path = os.path.join(self.client.client_cache.profiles_path, "clang")
+        save(clang_profile_path, profile)
         self.client.run("install Hello0/0.1@lasote/stable --build missing -pr clang", ignore_error=True)
         self.assertIn("Error reading 'clang' profile", self.client.user_io.out)
         self.assertIn("Bad syntax", self.client.user_io.out)
@@ -56,7 +57,7 @@ class ProfileTest(unittest.TestCase):
         [settings]
         [invented]
         '''
-        save(self.client.client_cache.profile_path("clang"), profile)
+        save(clang_profile_path, profile)
         self.client.run("install Hello0/0.1@lasote/stable --build missing -pr clang", ignore_error=True)
         self.assertIn("Unrecognized field 'invented'", self.client.user_io.out)
         self.assertIn("Error reading 'clang' profile", self.client.user_io.out)
@@ -65,7 +66,7 @@ class ProfileTest(unittest.TestCase):
         [settings]
         as
         '''
-        save(self.client.client_cache.profile_path("clang"), profile)
+        save(clang_profile_path, profile)
         self.client.run("install Hello0/0.1@lasote/stable --build missing -pr clang", ignore_error=True)
         self.assertIn("Error reading 'clang' profile: Invalid setting line 'as'", self.client.user_io.out)
 
@@ -73,7 +74,7 @@ class ProfileTest(unittest.TestCase):
         [env]
         as
         '''
-        save(self.client.client_cache.profile_path("clang"), profile)
+        save(clang_profile_path, profile)
         self.client.run("install Hello0/0.1@lasote/stable --build missing -pr clang", ignore_error=True)
         self.assertIn("Error reading 'clang' profile: Invalid env line 'as'", self.client.user_io.out)
 
@@ -81,7 +82,7 @@ class ProfileTest(unittest.TestCase):
         [scopes]
         as
         '''
-        save(self.client.client_cache.profile_path("clang"), profile)
+        save(clang_profile_path, profile)
         self.client.run("install Hello0/0.1@lasote/stable --build missing -pr clang", ignore_error=True)
         self.assertIn("Error reading 'clang' profile: Bad scope as", self.client.user_io.out)
 
@@ -89,7 +90,7 @@ class ProfileTest(unittest.TestCase):
         [settings]
         os =   a value
         '''
-        save(self.client.client_cache.profile_path("clang"), profile)
+        save(clang_profile_path, profile)
         self.client.run("install Hello0/0.1@lasote/stable --build missing -pr clang", ignore_error=True)
         # stripped "a value"
         self.assertIn("'a value' is not a valid 'settings.os'", self.client.user_io.out)
@@ -98,7 +99,7 @@ class ProfileTest(unittest.TestCase):
         [env]
         ENV_VAR =   a value
         '''
-        save(self.client.client_cache.profile_path("clang"), profile)
+        save(clang_profile_path, profile)
         self.client.run("install Hello0/0.1@lasote/stable --build missing -pr clang", ignore_error=True)
         self._assert_env_variable_printed("ENV_VAR", "a value")
 
@@ -108,7 +109,7 @@ class ProfileTest(unittest.TestCase):
         # Not even here
         ENV_VAR =   a value
         '''
-        save(self.client.client_cache.profile_path("clang"), profile)
+        save(clang_profile_path, profile)
         self.client.run("install Hello0/0.1@lasote/stable --build -pr clang", ignore_error=True)
         self._assert_env_variable_printed("ENV_VAR", "a value")
 
@@ -146,13 +147,12 @@ class ProfileTest(unittest.TestCase):
 
     def install_profile_settings_test(self):
         files = cpp_hello_conan_files("Hello0", "0.1", build=False)
-        files["conanfile.py"] = files["conanfile.py"].replace("generators =", "generators = \"txt\",")
 
         # Create a profile and use it
-        profile_settings = {"compiler": "Visual Studio",
-                            "compiler.version": "12",
-                            "compiler.runtime": "MD",
-                            "arch": "x86"}
+        profile_settings = OrderedDict([("compiler", "Visual Studio"),
+                                        ("compiler.version", "12"),
+                                        ("compiler.runtime", "MD"),
+                                        ("arch", "x86")])
 
         create_profile(self.client.client_cache.profiles_path, "vs_12_86",
                        settings=profile_settings, package_settings={})
@@ -211,6 +211,19 @@ class ProfileTest(unittest.TestCase):
         self.assertIn("compiler=gcc", info)
         self.assertNotIn("compiler.libcxx=libstdc++11", info)
         self.assertIn("compiler.libcxx=libstdc++", info)
+
+    def install_profile_options_test(self):
+        files = cpp_hello_conan_files("Hello0", "0.1", build=False)
+
+        create_profile(self.client.client_cache.profiles_path, "vs_12_86",
+                       options=[("Hello0:language", 1),
+                                ("Hello0:static", False)])
+
+        self.client.save(files)
+        self.client.run("install --build missing -pr vs_12_86")
+        info = load(os.path.join(self.client.current_folder, "conaninfo.txt"))
+        self.assertIn("language=1", info)
+        self.assertIn("static=False", info)
 
     def scopes_env_test(self):
         # Create a profile and use it

--- a/conans/test/integration/version_ranges_conflict_test.py
+++ b/conans/test/integration/version_ranges_conflict_test.py
@@ -1,0 +1,39 @@
+import unittest
+from conans.test.tools import TestClient
+from conans.paths import CONANFILE
+
+
+class VersionRangesConflictTest(unittest.TestCase):
+
+    def setUp(self):
+        conanfile = """
+from conans import ConanFile
+class MyConanA(ConanFile):
+    name = "%s"
+    version = "%s"
+    %s
+    """
+        self.client = TestClient()
+
+        def add(name, version, requires=None):
+            requires = "requires=%s" % ",".join('"%s"' % r for r in requires) if requires else ""
+            self.client.save({CONANFILE: conanfile % (name, version, requires)})
+            self.client.run("export user/testing")
+        add("MyPkg1", "0.1.0")
+        add("MyPkg1", "0.2.0")
+        add("MyPkg2", "0.1", ["MyPkg1/[~0.1]@user/testing"])
+        add("MyPkg3", "0.1", ["MyPkg1/[~0.2]@user/testing", "MyPkg2/[~0.1]@user/testing"])
+
+    def werror_warn_test(self):
+        self.client.run("info")
+        self.assertIn("WARN: Version range '~0.1' required by 'MyPkg2/0.1@user/testing' "
+                      "not valid for downstream requirement 'MyPkg1/0.2.0@user/testing'",
+                      self.client.user_io.out)
+
+    def werror_fail_test(self):
+        error = self.client.run("install --build --werror", ignore_error=True)
+        self.assertTrue(error)
+        self.assertNotIn("WARN: Version range '~0.1' required", self.client.user_io.out)
+        self.assertIn("ERROR: Version range '~0.1' required by 'MyPkg2/0.1@user/testing' "
+                      "not valid for downstream requirement 'MyPkg1/0.2.0@user/testing'",
+                      self.client.user_io.out)

--- a/conans/test/model/settings_test.py
+++ b/conans/test/model/settings_test.py
@@ -24,6 +24,27 @@ class SettingsTest(unittest.TestCase):
         sut.target = "native"
         self.assertTrue(sut.target == "native")
 
+    def multi_os_test(self):
+        settings = Settings.loads("""os:
+            Windows:
+            Linux:
+                distro: [RH6, RH7]
+            Macos:
+                codename: [Mavericks, Yosemite]
+        """)
+        settings.os = "Windows"
+        self.assertEqual(settings.os, "Windows")
+        settings.os = "Linux"
+        settings.os.distro = "RH6"
+        self.assertTrue(settings.os.distro == "RH6")
+        with self.assertRaises(ConanException):
+            settings.os.distro = "Other"
+        with self.assertRaises(ConanException):
+            settings.os.codename = "Yosemite"
+        settings.os = "Macos"
+        settings.os.codename = "Yosemite"
+        self.assertTrue(settings.os.codename == "Yosemite")
+
     def remove_test(self):
         self.sut.remove("compiler")
         self.sut.os = "Windows"

--- a/conans/test/path_limit_test.py
+++ b/conans/test/path_limit_test.py
@@ -4,7 +4,6 @@ from conans.util.files import load
 import os
 from conans.model.ref import PackageReference, ConanFileReference
 import platform
-import time
 
 
 base = '''

--- a/conans/test/tools_test.py
+++ b/conans/test/tools_test.py
@@ -78,7 +78,7 @@ class ToolsTest(unittest.TestCase):
     def system_package_tool_fail_when_not_0_returned_test(self):
         runner = RunnerMock(return_ok=False)
         spt = SystemPackageTool(runner=runner)
-        if platform.system() != "Windows":
+        if platform.system() == "Linux" or platform.system() == "Darwin":
             msg = "Command 'sudo apt-get update' failed" if platform.system() == "Linux" \
                                                          else "Command 'brew update' failed"
             with self.assertRaisesRegexp(ConanException, msg):
@@ -199,7 +199,7 @@ class ToolsTest(unittest.TestCase):
         self.assertEquals(7, runner.calls)
 
     def system_package_tool_installed_test(self):
-        if platform.system() == "Windows":
+        if platform.system() != "Linux" and platform.system() != "Macos":
             return
         spt = SystemPackageTool()
         # Git should be installed on development/testing machines
@@ -274,8 +274,8 @@ class HelloConan(ConanFile):
                            retry=3, retry_wait=0)
 
         # And OK
-        dest = os.path.join(temp_folder(), "README.txt")
-        tools.download("https://raw.githubusercontent.com/conan-io/conan/develop/README.rst",
+        dest = os.path.join(temp_folder(), "manual.html")
+        tools.download("http://www.zlib.net/manual.html",
                        dest, out=out,
                        retry=3, retry_wait=0)
 

--- a/conans/test/update_settings_yml_test.py
+++ b/conans/test/update_settings_yml_test.py
@@ -27,7 +27,7 @@ class ConanFileToolsTest(ConanFile):
     '''
         prev_settings = """
 os: [Windows, Linux, Macos, Android, FreeBSD, SunOS]
-arch: [x86, x86_64, armv6, armv7, armv7hf, armv8]
+arch: [x86, x86_64, armv6, armv7, armv7hf, armv8, sparc, sparcv9]
 compiler:
     sun-cc:
         version: ["5.10", "5.11", "5.12", "5.13", "5.14"]

--- a/conans/test/utils/profiles.py
+++ b/conans/test/utils/profiles.py
@@ -3,20 +3,24 @@ import os
 from conans.model.profile import Profile
 from conans.model.scope import Scopes
 from conans.util.files import save
+from conans.model.options import OptionsValues
 
 
 def create_profile(folder, name, settings=None, scopes=None, package_settings=None, env=None,
-                   package_env=None):
+                   package_env=None, options=None):
 
     package_env = package_env or {}
 
     profile = Profile()
-    profile._settings = settings or {}
+    profile.settings = settings or {}
     if scopes:
         profile.scopes = Scopes.from_list(["%s=%s" % (key, value) for key, value in scopes.items()])
 
     if package_settings:
-        profile._package_settings = package_settings
+        profile.package_settings = package_settings
+
+    if options:
+        profile.options = OptionsValues(options)
 
     for package_name, envs in package_env.items():
         for var_name, value in envs:

--- a/conans/tools.py
+++ b/conans/tools.py
@@ -65,7 +65,6 @@ def run_in_windows_bash(conanfile, bashcmd, cwd=None):
         conanfile.output.info('run_in_windows_bash: %s' % wincmd)
         conanfile.run(wincmd)
 
-
 @contextmanager
 def chdir(newdir):
     old_path = os.getcwd()


### PR DESCRIPTION
Merged with develop to solve conflicts. Most of the changes are from there, can be skipped

Most changes are very minor:
  - renamed ``filter`` (builtin word) => ``package_filter``
  - Linting (like removing trailing ; cleaning up spaces, lower_case_vars instead of mixedCaseVars
  - Extracted the print-paths functionality from the printing function, it was getting too long
  - Renamed outputFolder => output_folder, so it exactly matches the command line argument (filter)
  - Minor refactors to test, mostly linting, but also removed the "new", just using the given conanfile
  - Removed settings to tests, unnecessary

I have checked the folder creation issue, and the thing is that I think that showing the paths should be opt-in. It is an information that most users will not want, and the output is a bit cluttered. So I have added a ``--paths`` arg. 

It is true that folders are being created, but it seems it should be that way. It will not be a problem, because conan use a trailing ``/1`` subfolder that is used precisely so it is not being created and package creation workflow works. But once you ask for the path and the path is shortened, that cannot change. If the folder doesn't exist, there is a chance that such short random folder would be used by another package. I know, very unfortunate event, but still a chance. So better create and empty folder, not used, than having such a problem. And the creation of folders in any case would be restricted to ``--paths`` usage, and can be further restricted to ``--only=export_folder,package_folder`` if we don't want the empty intermediate source and build folder to be created.

TL;DR; making it opt-in, no big issue, can be merged.